### PR TITLE
Make repo clones more robust

### DIFF
--- a/backend/app/api/routes/projects.py
+++ b/backend/app/api/routes/projects.py
@@ -265,6 +265,8 @@ def create_project(
             template_git_repo_url = template_project.git_repo_url
             repo.git.remote(["add", "upstream", template_git_repo_url])
             repo.git.pull(["upstream", repo.active_branch.name])
+            # Remove upstream remote so we don't have any confusion later
+            repo.git.remote(["remove", "upstream"])
             template_repo = get_repo(
                 project=template_project,
                 session=session,

--- a/backend/app/git.py
+++ b/backend/app/git.py
@@ -75,9 +75,10 @@ def get_repo(
             with lock:
                 if ttl is None or ((time.time() - last_updated) > ttl):
                     logger.info("Updating remote in case token was refreshed")
-                    repo.remote().set_url(git_clone_url)
-                    logger.info("Git fetching")
                     branch_name = repo.active_branch.name
+                    repo.git.remote(["remove", "origin"])
+                    repo.git.remote(["add", "origin", git_clone_url])
+                    logger.info("Git fetching")
                     repo.git.fetch(["origin", branch_name])
                     repo.git.checkout([f"origin/{branch_name}"])
                     repo.git.branch(["-D", branch_name])


### PR DESCRIPTION
Something broke w.r.t. how this works for repos created from a template. The remote branches were missing even after fetching. This solution is more robust.