### PR TITLE
Allow expanding all contents from DVC lock file for all files page

### DIFF
--- a/backend/app/dvc.py
+++ b/backend/app/dvc.py
@@ -158,5 +158,9 @@ def expand_dvc_lock_outs(
                             dirname=outpath, type="file", stage=stage_name
                         )
             else:
-                dvc_lock_outs[outpath] = out
+                dvc_lock_outs[outpath] = out | dict(
+                    dirname=os.path.dirname(outpath),
+                    type="file",
+                    stage=stage_name,
+                )
     return dvc_lock_outs

--- a/backend/app/dvc.py
+++ b/backend/app/dvc.py
@@ -201,6 +201,7 @@ def expand_dvc_lock_outs(
                             type="file",
                             stage=stage_name,
                             relpath=fname,
+                            path=full_relpath,
                         )
             else:
                 dvc_lock_outs[outpath] = out | dict(

--- a/backend/app/dvc.py
+++ b/backend/app/dvc.py
@@ -131,7 +131,6 @@ def expand_dvc_lock_outs(
     for _, stage in stages.items():
         for out in stage.get("outs", []):
             outpath = out["path"]
-            print("Looking at outpath", outpath)
             md5 = out.get("md5", "")
             # If this is a directory, try to fetch its file from cloud storage
             # so we can read off all of the sub-outs

--- a/backend/app/dvc.py
+++ b/backend/app/dvc.py
@@ -128,7 +128,7 @@ def expand_dvc_lock_outs(
         fs = get_object_fs()
     stages = dvc_lock.get("stages", {})
     dvc_lock_outs = {}
-    for _, stage in stages.items():
+    for stage_name, stage in stages.items():
         for out in stage.get("outs", []):
             outpath = out["path"]
             md5 = out.get("md5", "")
@@ -146,10 +146,17 @@ def expand_dvc_lock_outs(
                         dvc_dir_contents = json.load(f)
                     dvc_lock_outs[outpath] = out
                     dvc_lock_outs[outpath]["children"] = dvc_dir_contents
+                    dvc_lock_outs[outpath]["dirname"] = os.path.dirname(
+                        outpath
+                    )
+                    dvc_lock_outs[outpath]["type"] = "dir"
+                    dvc_lock_outs[outpath]["stage"] = stage_name
                     for dvc_obj in dvc_dir_contents:
                         dvc_lock_outs[
                             os.path.join(outpath, dvc_obj["relpath"])
-                        ] = dvc_obj
+                        ] = dvc_obj | dict(
+                            dirname=outpath, type="file", stage=stage_name
+                        )
             else:
                 dvc_lock_outs[outpath] = out
     return dvc_lock_outs

--- a/backend/app/dvc.py
+++ b/backend/app/dvc.py
@@ -160,21 +160,38 @@ def expand_dvc_lock_outs(
                         relpath = dvc_obj["relpath"]
                         fname = os.path.basename(relpath)
                         subdir = os.path.dirname(relpath)
+                        md5 = dvc_obj.get("md5")
                         if subdir:
                             subdir_full_relpath = os.path.join(outpath, subdir)
                             if subdir_full_relpath not in dvc_lock_outs:
                                 dvc_lock_outs[subdir_full_relpath] = dict(
-                                    type="dir", children=[], dirname=outpath
+                                    type="dir",
+                                    children=[],
+                                    dirname=outpath,
+                                    stage=stage_name,
                                 )
                             dvc_lock_outs[subdir_full_relpath][
                                 "children"
-                            ].append(dict(relpath=fname))
+                            ].append(
+                                dict(
+                                    relpath=fname,
+                                    md5=md5,
+                                    type="file",
+                                    dirname=subdir_full_relpath,
+                                    stage=stage_name,
+                                )
+                            )
                             if (
                                 subdir_full_relpath
                                 not in dvc_lock_outs[outpath]["children"]
                             ):
                                 dvc_lock_outs[outpath]["children"].append(
-                                    dict(relpath=subdir, type="dir")
+                                    dict(
+                                        relpath=subdir,
+                                        type="dir",
+                                        stage=stage_name,
+                                        dirname=outpath,
+                                    )
                                 )
                         else:
                             subdir_full_relpath = outpath
@@ -183,6 +200,7 @@ def expand_dvc_lock_outs(
                             dirname=subdir_full_relpath,
                             type="file",
                             stage=stage_name,
+                            relpath=fname,
                         )
             else:
                 dvc_lock_outs[outpath] = out | dict(

--- a/backend/app/projects.py
+++ b/backend/app/projects.py
@@ -215,7 +215,7 @@ def get_contents_from_repo(
                     else "dir"
                 )
             elif p in dvc_lock_outs:
-                size = None
+                size = dvc_lock_outs[p].get("size")
                 obj_type = dvc_lock_outs[p]["type"]
             obj = dict(
                 name=os.path.basename(p),

--- a/backend/app/projects.py
+++ b/backend/app/projects.py
@@ -226,16 +226,7 @@ def get_contents_from_repo(
                 type=obj_type,
             )
             if p in ck_objects:
-                dvc_out = ck_outs.get(p)
                 obj["calkit_object"] = ck_objects[p]
-                obj["in_repo"] = False
-                if dvc_out is not None:
-                    obj["size"] = dvc_out.get("size")
-                    obj["type"] = (
-                        "dir"
-                        if dvc_out.get("md5", "").endswith(".dir")
-                        else "file"
-                    )
             else:
                 obj["calkit_object"] = None
             contents.append(ContentsItem.model_validate(obj))

--- a/backend/app/projects.py
+++ b/backend/app/projects.py
@@ -167,7 +167,7 @@ def get_contents_from_repo(
     for p, obj in ck_objects.items():
         # First check if this object is in the DVC lock outputs
         if p in dvc_lock_outs:
-            ck_outs = dvc_lock_outs[p]
+            ck_outs[p] = dvc_lock_outs[p]
         else:
             dvc_fp = os.path.join(repo_dir, p + ".dvc")
             if os.path.isfile(dvc_fp):
@@ -186,7 +186,8 @@ def get_contents_from_repo(
         or os.path.isdir(os.path.join(repo_dir, path))
         or path in dvc_lock_out_dirs
     ):
-        # We're listing off the top of the repo
+        # We're listing off the contents of a directory
+        logger.info(f"Getting contents of directory: {path}")
         dirname = "" if path is None else path
         contents = []
         if path not in dvc_lock_out_dirs:
@@ -314,8 +315,10 @@ def get_contents_from_repo(
         )
     # The file isn't in the repo, but maybe it's in the Calkit objects
     elif path in ck_objects:
+        logger.info(f"Looking in CK objects for {path}")
         dvc_out = ck_outs.get(path)
         if dvc_out is None:
+            logger.info(f"No DVC out for CK out at {path}")
             dvc_out = {}
         size = dvc_out.get("size")
         md5 = dvc_out.get("md5", "")

--- a/backend/app/projects.py
+++ b/backend/app/projects.py
@@ -231,7 +231,10 @@ def get_contents_from_repo(
                 obj["calkit_object"] = None
             contents.append(ContentsItem.model_validate(obj))
         for ck_path, ck_obj in ck_objects.items():
-            if os.path.dirname(ck_path) == dirname and ck_path not in paths:
+            if (
+                os.path.dirname(ck_path) == dirname
+                and ck_path not in all_paths
+            ):
                 # Read DVC output for this path
                 dvc_out = ck_outs.get(ck_path)
                 if dvc_out is None:

--- a/backend/app/tests/test_dvc.py
+++ b/backend/app/tests/test_dvc.py
@@ -87,3 +87,10 @@ def test_output_from_pipeline():
         lock=lock,
     )
     assert out is None
+
+
+def test_expand_dvc_lock_outs():
+    """This requires the `petebachant/snakemake-tutorial` project to be
+    populated in the dev environment.
+    """
+    pass  # TODO


### PR DESCRIPTION
Towards #82. The only thing missing is the expansion of directories not created with the pipeline, i.e., they have a `.dvc` file associated with them.