### PR TITLE
Split `useProject` hook into multiple hooks

### DIFF
--- a/frontend/src/components/Projects/ProjectShowcase.tsx
+++ b/frontend/src/components/Projects/ProjectShowcase.tsx
@@ -11,7 +11,7 @@ interface ProjectShowcaseProps {
 }
 
 function ProjectShowcase({ ownerName, projectName }: ProjectShowcaseProps) {
-  const { showcaseRequest } = useProject(ownerName, projectName, false)
+  const { showcaseRequest } = useProject(ownerName, projectName)
   return (
     <>
       {showcaseRequest.isPending ? (

--- a/frontend/src/hooks/useProject.ts
+++ b/frontend/src/hooks/useProject.ts
@@ -18,20 +18,13 @@ const useProject = (userName: string, projectName: string) => {
       }
       return failureCount < 3
     },
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
   })
 
   const userHasWriteAccess = ["owner", "admin", "write"].includes(
     String(projectRequest.data?.current_user_access),
   )
-
-  const questionsRequest = useQuery({
-    queryKey: ["projects", userName, projectName, "questions"],
-    queryFn: () =>
-      ProjectsService.getProjectQuestions({
-        ownerName: userName,
-        projectName: projectName,
-      }),
-  })
 
   const reproCheckRequest = useQuery({
     queryKey: ["projects", userName, projectName, "repro-check"],
@@ -70,7 +63,6 @@ const useProject = (userName: string, projectName: string) => {
   return {
     projectRequest,
     userHasWriteAccess,
-    questionsRequest,
     reproCheckRequest,
     showcaseRequest,
     putDevcontainerMutation,
@@ -88,6 +80,18 @@ const useProjectReadme = (userName: string, projectName: string) => {
       }),
   })
   return { readmeRequest }
+}
+
+const useProjectQuestions = (userName: string, projectName: string) => {
+  const questionsRequest = useQuery({
+    queryKey: ["projects", userName, projectName, "questions"],
+    queryFn: () =>
+      ProjectsService.getProjectQuestions({
+        ownerName: userName,
+        projectName: projectName,
+      }),
+  })
+  return { questionsRequest }
 }
 
 const useProjectFigures = (userName: string, projectName: string) => {
@@ -187,5 +191,6 @@ export {
   useProjectReadme,
   useProjectDatasets,
   useProjectIssues,
+  useProjectQuestions,
 }
 export default useProject

--- a/frontend/src/hooks/useProject.ts
+++ b/frontend/src/hooks/useProject.ts
@@ -97,15 +97,6 @@ const useProject = (
       }),
   })
 
-  const filesRequest = useQuery({
-    queryKey: ["projects", userName, projectName, "files"],
-    queryFn: () =>
-      ProjectsService.getProjectContents({
-        ownerName: userName,
-        projectName: projectName,
-      }),
-  })
-
   const showcaseRequest = useQuery({
     queryKey: ["projects", userName, projectName, "showcase"],
     queryFn: () =>
@@ -156,7 +147,6 @@ const useProject = (
     publicationsRequest,
     issuesRequest,
     questionsRequest,
-    filesRequest,
     reproCheckRequest,
     showcaseRequest,
     issueStateMutation,
@@ -164,4 +154,17 @@ const useProject = (
   }
 }
 
+const useProjectFiles = (userName: string, projectName: string) => {
+  const filesRequest = useQuery({
+    queryKey: ["projects", userName, projectName, "files"],
+    queryFn: () =>
+      ProjectsService.getProjectContents({
+        ownerName: userName,
+        projectName: projectName,
+      }),
+  })
+  return { filesRequest }
+}
+
+export { useProjectFiles }
 export default useProject

--- a/frontend/src/hooks/useProject.ts
+++ b/frontend/src/hooks/useProject.ts
@@ -60,15 +60,6 @@ const useProject = (
     refetchOnMount: false,
   })
 
-  const datasetsRequest = useQuery({
-    queryKey: ["projects", userName, projectName, "datasets"],
-    queryFn: () =>
-      ProjectsService.getProjectDatasets({
-        ownerName: userName,
-        projectName: projectName,
-      }),
-  })
-
   const showcaseRequest = useQuery({
     queryKey: ["projects", userName, projectName, "showcase"],
     queryFn: () =>
@@ -113,7 +104,6 @@ const useProject = (
   return {
     projectRequest,
     userHasWriteAccess,
-    datasetsRequest,
     issuesRequest,
     questionsRequest,
     reproCheckRequest,
@@ -160,6 +150,19 @@ const useProjectFiles = (userName: string, projectName: string) => {
   return { filesRequest }
 }
 
+const useProjectDatasets = (userName: string, projectName: string) => {
+  const datasetsRequest = useQuery({
+    queryKey: ["projects", userName, projectName, "datasets"],
+    queryFn: () =>
+      ProjectsService.getProjectDatasets({
+        ownerName: userName,
+        projectName: projectName,
+      }),
+  })
+
+  return { datasetsRequest }
+}
+
 const useProjectPublications = (userName: string, projectName: string) => {
   const publicationsRequest = useQuery({
     queryKey: ["projects", userName, projectName, "publications"],
@@ -177,5 +180,6 @@ export {
   useProjectFigures,
   useProjectPublications,
   useProjectReadme,
+  useProjectDatasets,
 }
 export default useProject

--- a/frontend/src/hooks/useProject.ts
+++ b/frontend/src/hooks/useProject.ts
@@ -79,15 +79,6 @@ const useProject = (
       }),
   })
 
-  const figuresRequest = useQuery({
-    queryKey: ["projects", userName, projectName, "figures"],
-    queryFn: () =>
-      ProjectsService.getProjectFigures({
-        ownerName: userName,
-        projectName: projectName,
-      }),
-  })
-
   const publicationsRequest = useQuery({
     queryKey: ["projects", userName, projectName, "publications"],
     queryFn: () =>
@@ -143,7 +134,6 @@ const useProject = (
     userHasWriteAccess,
     readmeRequest,
     datasetsRequest,
-    figuresRequest,
     publicationsRequest,
     issuesRequest,
     questionsRequest,
@@ -152,6 +142,18 @@ const useProject = (
     issueStateMutation,
     putDevcontainerMutation,
   }
+}
+
+const useProjectFigures = (userName: string, projectName: string) => {
+  const figuresRequest = useQuery({
+    queryKey: ["projects", userName, projectName, "figures"],
+    queryFn: () =>
+      ProjectsService.getProjectFigures({
+        ownerName: userName,
+        projectName: projectName,
+      }),
+  })
+  return { figuresRequest }
 }
 
 const useProjectFiles = (userName: string, projectName: string) => {
@@ -166,5 +168,5 @@ const useProjectFiles = (userName: string, projectName: string) => {
   return { filesRequest }
 }
 
-export { useProjectFiles }
+export { useProjectFiles, useProjectFigures }
 export default useProject

--- a/frontend/src/hooks/useProject.ts
+++ b/frontend/src/hooks/useProject.ts
@@ -79,15 +79,6 @@ const useProject = (
       }),
   })
 
-  const publicationsRequest = useQuery({
-    queryKey: ["projects", userName, projectName, "publications"],
-    queryFn: () =>
-      ProjectsService.getProjectPublications({
-        ownerName: userName,
-        projectName: projectName,
-      }),
-  })
-
   const showcaseRequest = useQuery({
     queryKey: ["projects", userName, projectName, "showcase"],
     queryFn: () =>
@@ -134,7 +125,6 @@ const useProject = (
     userHasWriteAccess,
     readmeRequest,
     datasetsRequest,
-    publicationsRequest,
     issuesRequest,
     questionsRequest,
     reproCheckRequest,
@@ -168,5 +158,17 @@ const useProjectFiles = (userName: string, projectName: string) => {
   return { filesRequest }
 }
 
-export { useProjectFiles, useProjectFigures }
+const useProjectPublications = (userName: string, projectName: string) => {
+  const publicationsRequest = useQuery({
+    queryKey: ["projects", userName, projectName, "publications"],
+    queryFn: () =>
+      ProjectsService.getProjectPublications({
+        ownerName: userName,
+        projectName: projectName,
+      }),
+  })
+  return { publicationsRequest }
+}
+
+export { useProjectFiles, useProjectFigures, useProjectPublications }
 export default useProject

--- a/frontend/src/hooks/useProject.ts
+++ b/frontend/src/hooks/useProject.ts
@@ -28,16 +28,6 @@ const useProject = (
     String(projectRequest.data?.current_user_access),
   )
 
-  const readmeRequest = useQuery({
-    queryKey: ["projects", userName, projectName, "readme"],
-    queryFn: () =>
-      ProjectsService.getProjectContents({
-        ownerName: userName,
-        projectName: projectName,
-        path: "README.md",
-      }),
-  })
-
   const issuesRequest = useQuery({
     queryKey: ["projects", userName, projectName, "issues", showClosedTodos],
     queryFn: () =>
@@ -123,7 +113,6 @@ const useProject = (
   return {
     projectRequest,
     userHasWriteAccess,
-    readmeRequest,
     datasetsRequest,
     issuesRequest,
     questionsRequest,
@@ -132,6 +121,19 @@ const useProject = (
     issueStateMutation,
     putDevcontainerMutation,
   }
+}
+
+const useProjectReadme = (userName: string, projectName: string) => {
+  const readmeRequest = useQuery({
+    queryKey: ["projects", userName, projectName, "readme"],
+    queryFn: () =>
+      ProjectsService.getProjectContents({
+        ownerName: userName,
+        projectName: projectName,
+        path: "README.md",
+      }),
+  })
+  return { readmeRequest }
 }
 
 const useProjectFigures = (userName: string, projectName: string) => {
@@ -170,5 +172,10 @@ const useProjectPublications = (userName: string, projectName: string) => {
   return { publicationsRequest }
 }
 
-export { useProjectFiles, useProjectFigures, useProjectPublications }
+export {
+  useProjectFiles,
+  useProjectFigures,
+  useProjectPublications,
+  useProjectReadme,
+}
 export default useProject

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -26,7 +26,7 @@ mixpanel.init(mixpanelToken, {
 
 const queryClient = new QueryClient({
   defaultOptions: {
-    queries: { refetchOnWindowFocus: false, refetchOnMount: false },
+    queries: { refetchOnWindowFocus: false, refetchOnMount: true },
   },
 })
 

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout.tsx
@@ -324,7 +324,6 @@ function ProjectLayout() {
   const { projectRequest, userHasWriteAccess } = useProject(
     userName,
     projectName,
-    false,
   )
   const isPending = projectRequest.isPending
   const error = projectRequest.error

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/datasets.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/datasets.tsx
@@ -22,7 +22,7 @@ import { FaPlus } from "react-icons/fa"
 
 import DatasetFromExisting from "../../../../../components/Datasets/DatasetFromExisting"
 import UploadDataset from "../../../../../components/Datasets/UploadDataset"
-import useProject from "../../../../../hooks/useProject"
+import useProject, { useProjectDatasets } from "../../../../../hooks/useProject"
 
 export const Route = createFileRoute(
   "/_layout/$userName/$projectName/_layout/datasets",
@@ -32,11 +32,8 @@ export const Route = createFileRoute(
 
 function ProjectDataView() {
   const { userName, projectName } = Route.useParams()
-  const { datasetsRequest, userHasWriteAccess } = useProject(
-    userName,
-    projectName,
-    false,
-  )
+  const { userHasWriteAccess } = useProject(userName, projectName, false)
+  const { datasetsRequest } = useProjectDatasets(userName, projectName)
   const { isPending: dataPending, data: datasets } = datasetsRequest
   const uploadDataModal = useDisclosure()
   const labelDataModal = useDisclosure()

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/datasets.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/datasets.tsx
@@ -32,7 +32,7 @@ export const Route = createFileRoute(
 
 function ProjectDataView() {
   const { userName, projectName } = Route.useParams()
-  const { userHasWriteAccess } = useProject(userName, projectName, false)
+  const { userHasWriteAccess } = useProject(userName, projectName)
   const { datasetsRequest } = useProjectDatasets(userName, projectName)
   const { isPending: dataPending, data: datasets } = datasetsRequest
   const uploadDataModal = useDisclosure()

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/figures.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/figures.tsx
@@ -233,7 +233,7 @@ const getIcon = (figure: Figure) => {
 
 function ProjectFigures() {
   const { userName, projectName } = Route.useParams()
-  const { userHasWriteAccess } = useProject(userName, projectName, false)
+  const { userHasWriteAccess } = useProject(userName, projectName)
   const { figuresRequest } = useProjectFigures(userName, projectName)
   const { isPending: figuresPending, data: figures } = figuresRequest
   const uploadFigureModal = useDisclosure()

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/figures.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/figures.tsx
@@ -31,7 +31,7 @@ import {
   type FigureCommentPost,
 } from "../../../../../client"
 import PageMenu from "../../../../../components/Common/PageMenu"
-import useProject from "../../../../../hooks/useProject"
+import useProject, { useProjectFigures } from "../../../../../hooks/useProject"
 import useAuth from "../../../../../hooks/useAuth"
 import FigureView from "../../../../../components/Figures/FigureView"
 
@@ -233,11 +233,8 @@ const getIcon = (figure: Figure) => {
 
 function ProjectFigures() {
   const { userName, projectName } = Route.useParams()
-  const { figuresRequest, userHasWriteAccess } = useProject(
-    userName,
-    projectName,
-    false,
-  )
+  const { userHasWriteAccess } = useProject(userName, projectName, false)
+  const { figuresRequest } = useProjectFigures(userName, projectName)
   const { isPending: figuresPending, data: figures } = figuresRequest
   const uploadFigureModal = useDisclosure()
   const labelFigureModal = useDisclosure()

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/files.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/files.tsx
@@ -31,7 +31,7 @@ import UploadFile from "../../../../../components/Files/UploadFile"
 import PageMenu from "../../../../../components/Common/PageMenu"
 import FileContent from "../../../../../components/Files/FileContent"
 import SelectedItemInfo from "../../../../../components/Files/SelectedItemInfo"
-import useProject from "../../../../../hooks/useProject"
+import useProject, { useProjectFiles } from "../../../../../hooks/useProject"
 
 const fileSearchSchema = z.object({ path: z.string().catch("") })
 
@@ -213,11 +213,8 @@ function Item({ item, level, selectedPath, setSelectedPath }: ItemProps) {
 function Files() {
   const { userName, projectName } = Route.useParams()
   const { path } = Route.useSearch()
-  const { filesRequest, userHasWriteAccess } = useProject(
-    userName,
-    projectName,
-    false,
-  )
+  const { userHasWriteAccess } = useProject(userName, projectName, false)
+  const { filesRequest } = useProjectFiles(userName, projectName)
   const {
     isPending: filesPending,
     data: files,

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/files.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/files.tsx
@@ -213,7 +213,7 @@ function Item({ item, level, selectedPath, setSelectedPath }: ItemProps) {
 function Files() {
   const { userName, projectName } = Route.useParams()
   const { path } = Route.useSearch()
-  const { userHasWriteAccess } = useProject(userName, projectName, false)
+  const { userHasWriteAccess } = useProject(userName, projectName)
   const { filesRequest } = useProjectFiles(userName, projectName)
   const {
     isPending: filesPending,

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/index.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/index.tsx
@@ -28,7 +28,7 @@ import Markdown from "../../../../../components/Common/Markdown"
 import CreateIssue from "../../../../../components/Projects/CreateIssue"
 import CreateQuestion from "../../../../../components/Projects/CreateQuestion"
 import NewPublication from "../../../../../components/Publications/NewPublication"
-import useProject from "../../../../../hooks/useProject"
+import useProject, { useProjectReadme } from "../../../../../hooks/useProject"
 import ProjectShowcase from "../../../../../components/Projects/ProjectShowcase"
 
 export const Route = createFileRoute(
@@ -43,7 +43,6 @@ function ProjectView() {
   const [showClosedTodos, setShowClosedTodos] = useState(false)
   const {
     projectRequest,
-    readmeRequest,
     issuesRequest,
     questionsRequest,
     reproCheckRequest,
@@ -51,6 +50,7 @@ function ProjectView() {
     putDevcontainerMutation,
     userHasWriteAccess,
   } = useProject(userName, projectName, showClosedTodos)
+  const { readmeRequest } = useProjectReadme(userName, projectName)
   const reproCheck = reproCheckRequest.data
   const gitRepoUrl = projectRequest.data?.git_repo_url
   const codespacesUrl =

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/index.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/index.tsx
@@ -28,7 +28,10 @@ import Markdown from "../../../../../components/Common/Markdown"
 import CreateIssue from "../../../../../components/Projects/CreateIssue"
 import CreateQuestion from "../../../../../components/Projects/CreateQuestion"
 import NewPublication from "../../../../../components/Publications/NewPublication"
-import useProject, { useProjectReadme } from "../../../../../hooks/useProject"
+import useProject, {
+  useProjectIssues,
+  useProjectReadme,
+} from "../../../../../hooks/useProject"
 import ProjectShowcase from "../../../../../components/Projects/ProjectShowcase"
 
 export const Route = createFileRoute(
@@ -43,13 +46,16 @@ function ProjectView() {
   const [showClosedTodos, setShowClosedTodos] = useState(false)
   const {
     projectRequest,
-    issuesRequest,
     questionsRequest,
     reproCheckRequest,
-    issueStateMutation,
     putDevcontainerMutation,
     userHasWriteAccess,
-  } = useProject(userName, projectName, showClosedTodos)
+  } = useProject(userName, projectName)
+  const { issuesRequest, issueStateMutation } = useProjectIssues(
+    userName,
+    projectName,
+    showClosedTodos,
+  )
   const { readmeRequest } = useProjectReadme(userName, projectName)
   const reproCheck = reproCheckRequest.data
   const gitRepoUrl = projectRequest.data?.git_repo_url

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/index.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/index.tsx
@@ -30,6 +30,7 @@ import CreateQuestion from "../../../../../components/Projects/CreateQuestion"
 import NewPublication from "../../../../../components/Publications/NewPublication"
 import useProject, {
   useProjectIssues,
+  useProjectQuestions,
   useProjectReadme,
 } from "../../../../../hooks/useProject"
 import ProjectShowcase from "../../../../../components/Projects/ProjectShowcase"
@@ -46,7 +47,6 @@ function ProjectView() {
   const [showClosedTodos, setShowClosedTodos] = useState(false)
   const {
     projectRequest,
-    questionsRequest,
     reproCheckRequest,
     putDevcontainerMutation,
     userHasWriteAccess,
@@ -57,6 +57,7 @@ function ProjectView() {
     showClosedTodos,
   )
   const { readmeRequest } = useProjectReadme(userName, projectName)
+  const { questionsRequest } = useProjectQuestions(userName, projectName)
   const reproCheck = reproCheckRequest.data
   const gitRepoUrl = projectRequest.data?.git_repo_url
   const codespacesUrl =

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/publications.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/publications.tsx
@@ -23,7 +23,9 @@ import { FaPlus } from "react-icons/fa"
 import { type Publication } from "../../../../../client"
 import NewPublication from "../../../../../components/Publications/NewPublication"
 import PageMenu from "../../../../../components/Common/PageMenu"
-import useProject from "../../../../../hooks/useProject"
+import useProject, {
+  useProjectPublications,
+} from "../../../../../hooks/useProject"
 import PublicationView from "../../../../../components/Publications/PublicationView"
 
 export const Route = createFileRoute(
@@ -95,11 +97,8 @@ function Publications() {
   const labelPubModal = useDisclosure()
   const newPubTemplateModal = useDisclosure()
   const { userName, projectName } = Route.useParams()
-  const { publicationsRequest, userHasWriteAccess } = useProject(
-    userName,
-    projectName,
-    false,
-  )
+  const { userHasWriteAccess } = useProject(userName, projectName, false)
+  const { publicationsRequest } = useProjectPublications(userName, projectName)
 
   return (
     <>

--- a/frontend/src/routes/_layout/$userName/$projectName/_layout/publications.tsx
+++ b/frontend/src/routes/_layout/$userName/$projectName/_layout/publications.tsx
@@ -97,7 +97,7 @@ function Publications() {
   const labelPubModal = useDisclosure()
   const newPubTemplateModal = useDisclosure()
   const { userName, projectName } = Route.useParams()
-  const { userHasWriteAccess } = useProject(userName, projectName, false)
+  const { userHasWriteAccess } = useProject(userName, projectName)
   const { publicationsRequest } = useProjectPublications(userName, projectName)
 
   return (


### PR DESCRIPTION
Reduces the number of queries significantly, towards #319 