### PR TITLE
Always create orgs with lowercase names

### DIFF
--- a/backend/app/api/routes/orgs.py
+++ b/backend/app/api/routes/orgs.py
@@ -77,7 +77,7 @@ class OrgPost(BaseModel):
 def post_org(
     req: OrgPost, session: SessionDep, current_user: CurrentUser
 ) -> OrgPublic:
-    org_name = req.name or req.github_name
+    org_name = (req.name or req.github_name).lower()
     if org_name in INVALID_ACCOUNT_NAMES:
         raise HTTPException(422, "Invalid account name")
     if get_org_from_db(org_name=org_name, session=session) is not None:


### PR DESCRIPTION
The display names and GitHub names can have whatever case they want, but the name in the Calkit database should be all lowercase.