### PR TITLE
Add logging and try to optimize presigned URL generation for repo contents larger than 1 MB in size

### DIFF
--- a/backend/app/projects.py
+++ b/backend/app/projects.py
@@ -183,6 +183,7 @@ def get_contents_from_repo(
     dvc_lock_fpath = os.path.join(repo_dir, "dvc.lock")
     dvc_lock = {}
     if os.path.isfile(dvc_lock_fpath):
+        logger.info("Reading dvc.lock")
         with open(dvc_lock_fpath) as f:
             dvc_lock = yaml.safe_load(f)
     # Expand all DVC lock outs


### PR DESCRIPTION
This is an issue with the BOOM paper repo. The paper and the workflow diagram are both ~5 MB. It seems to be a bit slow to hash them and check for their existence in cloud storage before returning a pre-signed URL.